### PR TITLE
feat: 플래시 세일 상품 단일 조회

### DIFF
--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FlashSaleProductService.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FlashSaleProductService.java
@@ -43,6 +43,15 @@ public class FlashSaleProductService {
         return flashSaleProductMapper.convertToResponseDto(flashSaleProduct, flashSaleResponseDto);
     }
 
+    public FlashSaleProductResponseDto getOne(UUID flashSaleProductId) {
+        FlashSaleProduct flashSaleProduct = existFlashSaleProduct(flashSaleProductId);
+
+        FlashSale flashSale = flashSaleService.existFlashSale(flashSaleProduct.getFlashSale().getId());
+        FlashSaleResponseDto flashSaleResponseDto = flashSaleMapper.convertToResponseDto(flashSale);
+
+        return flashSaleProductMapper.convertToResponseDto(flashSaleProduct, flashSaleResponseDto);
+    }
+
     public List<FlashSaleProductResponseDto> getList(UUID flashSaleId, List<FlashSaleProductStatus> statusList) {
         List<FlashSaleProduct> flashSaleProductList;
 
@@ -60,6 +69,7 @@ public class FlashSaleProductService {
         {
             FlashSale flashSale = flashSaleService.existFlashSale(flashSaleProduct.getFlashSale().getId());
             FlashSaleResponseDto flashSaleResponseDto = flashSaleMapper.convertToResponseDto(flashSale);
+
             return flashSaleProductMapper.convertToResponseDto(flashSaleProduct, flashSaleResponseDto);
         }).toList();
     }

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/presentation/controller/FlashSaleProductController.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/presentation/controller/FlashSaleProductController.java
@@ -24,6 +24,11 @@ public class FlashSaleProductController {
         return ResponseEntity.ok(flashSaleProductService.create(flashSaleProductRequestDto));
     }
 
+    @GetMapping("/{flashSaleProductId}")
+    public ResponseEntity<FlashSaleProductResponseDto> getOne(@PathVariable("flashSaleProductId") UUID flashSaleProductId) {
+        return ResponseEntity.ok(flashSaleProductService.getOne(flashSaleProductId));
+    }
+
     @GetMapping()
     public ResponseEntity<List<FlashSaleProductResponseDto>> getList(
         @RequestParam(value = "flashSaleId", required = false) UUID flashSaleId,


### PR DESCRIPTION
플래시 세일 상품 단일 조회 API를 추가하였습니다.

또한 현재 FlashSaleProductResponseDto내부에 FlashSaleResponseDto도 존재하는데 해당 Dto의 정보와 Mapper의 사용 위치를 아직 고민중에 있어 중복된 코드가 존재합니다. 해당 코드는 상품정보까지 가져온 후 수정하겠습니다.