### PR TITLE
User crud 구현

### DIFF
--- a/com.flash.auth/src/main/java/com/flash/auth/presentation/controller/AuthController.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/presentation/controller/AuthController.java
@@ -26,13 +26,17 @@ public class AuthController {
     private final AuthService authService;
     private final CookieUtil cookieUtil;
 
+    // @PreAuthorize("isAnonymous()")
     @PostMapping("/join")
     public ResponseEntity<JoinResponseDto> join(@RequestBody @Valid JoinRequestDto joinRequestDto) {
         return ResponseEntity.ok(authService.join(joinRequestDto));
     }
 
+    // 로그인 요청을 계속 보내지 못하도록 막는 방법은?
+    // @PreAuthorize("isAnonymous()")
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginRequestDto loginRequestDto, HttpServletResponse response) {
+        // refresh token을 redis에 저장할 예정인데, 그게 있으면 return ?
         LoginResponseDto loginResponseDto = authService.attemptAuthentication(loginRequestDto);
         response.addHeader(AUTHORIZATION_HEADER, loginResponseDto.accessToken());
         response.addCookie(cookieUtil.createCookieWithRefreshToken(loginResponseDto.refreshToken()));

--- a/com.flash.base/src/main/java/com/flash/base/jpa/BaseEntity.java
+++ b/com.flash.base/src/main/java/com/flash/base/jpa/BaseEntity.java
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -38,9 +39,9 @@ public class BaseEntity implements Serializable {
     private boolean isDeleted = false;
 
     // TODO: deletedBy는 Security 구현 후 수정
-    public void delete(String userId) {
+    public void delete() {
         this.deletedAt = LocalDateTime.now();
-        this.deletedBy = userId;
+        this.deletedBy = SecurityContextHolder.getContext().getAuthentication().getName();
         this.isDeleted = true;
     }
 

--- a/com.flash.user/build.gradle
+++ b/com.flash.user/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':base')
 
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.postgresql:postgresql'

--- a/com.flash.user/src/main/java/com/flash/user/application/dto/request/UpdateRequestDto.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/dto/request/UpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.flash.user.application.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateRequestDto(
+        String address,
+        @Size(min = 13, max = 13)
+        @Pattern(regexp = "\\d{3}-\\d{4}-\\d{4}",
+                message = "000-1234-1234 형식에 맞게 입력해주세요")
+        String phone,
+        String name
+) {
+}

--- a/com.flash.user/src/main/java/com/flash/user/application/dto/response/UserInfoResponseDto.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,13 @@
+package com.flash.user.application.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UserInfoResponseDto(
+        String email,
+        String role,
+        String address,
+        String phone,
+        String name
+) {
+}

--- a/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
@@ -41,14 +41,17 @@ public class UserService {
         return UserMapper.dtoFrom(saved);
     }
 
-    public UserResponseDto getUserInfo(String userId) {
-        User user = userRepository.findById(Long.valueOf(userId)).orElseThrow(() -> {
-            // TODO: 커스텀 예외 만들어서 던지기
-            log.error("user not found by id");
-            throw new IllegalArgumentException("user not found by id");
+    public User getUser(String userId) {
+        return userRepository.findById(Long.valueOf(userId)).orElseThrow(
+                () -> {
+                    log.error("getUser method: user not found by id");
+                    throw new IllegalArgumentException("user not found by id");
+                }
+        );
+    }
 
-        });
-        return UserMapper.toVendorFrom(user);
+    public UserResponseDto getUserInfoForVendor(String userId) {
+        return UserMapper.toVendorFrom(getUser(userId));
     }
 
     public LoginResponseDto verify(LoginRequestDto loginRequestDto) {

--- a/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
@@ -4,6 +4,7 @@ import com.flash.user.application.dto.request.JoinRequestDto;
 import com.flash.user.application.dto.request.LoginRequestDto;
 import com.flash.user.application.dto.response.JoinResponseDto;
 import com.flash.user.application.dto.response.LoginResponseDto;
+import com.flash.user.application.dto.response.UserInfoResponseDto;
 import com.flash.user.application.dto.response.UserResponseDto;
 import com.flash.user.application.service.mapper.UserMapper;
 import com.flash.user.domain.model.User;
@@ -69,4 +70,7 @@ public class UserService {
         return UserMapper.toAuthFrom(user);
     }
 
+    public UserInfoResponseDto getUserInfo(String userId) {
+        return UserMapper.toUserInfoFrom(getUser(userId));
+    }
 }

--- a/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
@@ -7,7 +7,7 @@ import com.flash.user.application.dto.response.JoinResponseDto;
 import com.flash.user.application.dto.response.LoginResponseDto;
 import com.flash.user.application.dto.response.UserInfoResponseDto;
 import com.flash.user.application.dto.response.UserResponseDto;
-import com.flash.user.application.service.mapper.UserMapper;
+import com.flash.user.application.service.util.UserMapper;
 import com.flash.user.domain.model.User;
 import com.flash.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -54,9 +54,10 @@ public class UserService {
     }
 
     public UserResponseDto getUserInfoForVendor(String userId) {
-        return UserMapper.toVendorFrom(getUser(userId));
+        return UserMapper.getNameFrom(getUser(userId));
     }
 
+    @Transactional(readOnly = true)
     public LoginResponseDto verify(LoginRequestDto loginRequestDto) {
         User user = userRepository.findByEmail(loginRequestDto.email()).orElseThrow(() -> {
             // TODO: 커스텀 예외 만들어서 던지기
@@ -84,4 +85,13 @@ public class UserService {
         user.setName(updateRequestDto.name() != null ? updateRequestDto.name() : user.getName());
         return UserMapper.toUserInfoFrom(user);
     }
+
+    @Transactional
+    public UserResponseDto deleteUser(String userId) {
+        User user = getUser(userId);
+        user.delete();
+
+        return UserMapper.getNameFrom(user);
+    }
+
 }

--- a/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
@@ -12,6 +12,10 @@ import com.flash.user.domain.model.User;
 import com.flash.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,6 +96,23 @@ public class UserService {
         user.delete();
 
         return UserMapper.getNameFrom(user);
+    }
+
+    public Page<UserInfoResponseDto> getUserList(int page, int size, String sortBy, boolean isAsc) {
+        // 페이징 처리를 하기 위한 Sort 객체 생성
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        // page, size, Sort 객체로 Pageable 객체 완성
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Page<User> all = userRepository.findAll(pageable);
+        if (all.isEmpty()) {
+            log.error("user list is empty");
+            // TODO: 커스텀 예외 변경
+            throw new IllegalArgumentException("user list is empty");
+        }
+
+        return all.map(UserMapper::toUserInfoFrom);
     }
 
 }

--- a/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/UserService.java
@@ -2,6 +2,7 @@ package com.flash.user.application.service;
 
 import com.flash.user.application.dto.request.JoinRequestDto;
 import com.flash.user.application.dto.request.LoginRequestDto;
+import com.flash.user.application.dto.request.UpdateRequestDto;
 import com.flash.user.application.dto.response.JoinResponseDto;
 import com.flash.user.application.dto.response.LoginResponseDto;
 import com.flash.user.application.dto.response.UserInfoResponseDto;
@@ -42,6 +43,7 @@ public class UserService {
         return UserMapper.dtoFrom(saved);
     }
 
+    @Transactional(readOnly = true)
     public User getUser(String userId) {
         return userRepository.findById(Long.valueOf(userId)).orElseThrow(
                 () -> {
@@ -72,5 +74,14 @@ public class UserService {
 
     public UserInfoResponseDto getUserInfo(String userId) {
         return UserMapper.toUserInfoFrom(getUser(userId));
+    }
+
+    @Transactional
+    public UserInfoResponseDto updateUser(String userId, UpdateRequestDto updateRequestDto) {
+        User user = getUser(userId);
+        user.setAddress(updateRequestDto.address() != null ? updateRequestDto.address() : user.getAddress());
+        user.setPhone(updateRequestDto.phone() != null ? updateRequestDto.phone() : user.getPhone());
+        user.setName(updateRequestDto.name() != null ? updateRequestDto.name() : user.getName());
+        return UserMapper.toUserInfoFrom(user);
     }
 }

--- a/com.flash.user/src/main/java/com/flash/user/application/service/mapper/UserMapper.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package com.flash.user.application.service.mapper;
 import com.flash.user.application.dto.request.JoinRequestDto;
 import com.flash.user.application.dto.response.JoinResponseDto;
 import com.flash.user.application.dto.response.LoginResponseDto;
+import com.flash.user.application.dto.response.UserInfoResponseDto;
 import com.flash.user.application.dto.response.UserResponseDto;
 import com.flash.user.domain.model.RoleEnum;
 import com.flash.user.domain.model.User;
@@ -41,6 +42,16 @@ public class UserMapper {
         return LoginResponseDto.builder()
                 .id(String.valueOf(user.getId()))
                 .role(user.getRole().getAuthority())
+                .build();
+    }
+
+    public static UserInfoResponseDto toUserInfoFrom(User user) {
+        return UserInfoResponseDto.builder()
+                .email(user.getEmail())
+                .role(user.getRole().getAuthority())
+                .address(user.getAddress())
+                .phone(user.getPhone())
+                .name(user.getName())
                 .build();
     }
 }

--- a/com.flash.user/src/main/java/com/flash/user/application/service/util/UserAuthService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/util/UserAuthService.java
@@ -1,0 +1,37 @@
+package com.flash.user.application.service.util;
+
+import com.flash.user.domain.model.RoleEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Component
+@RequiredArgsConstructor
+public class UserAuthService {
+
+    public void verifyIdentity(String userId) {
+        // 현재 인증된 사용자의 정보를 가져옴
+        String authenticatedUserId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        // 인증된 사용자의 ID와 전달된 userId가 같은지 확인
+        if (userId.equals(authenticatedUserId)) {
+            return;
+        }
+
+        // 다르면 권한이 MASTER인지 확인
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+        for (GrantedAuthority authority : authorities) {
+            if (authority.getAuthority().equals(RoleEnum.MASTER)) {
+                return;  // MASTER 권한이면 return
+            }
+        }
+
+        // TODO: 커스텀 예외
+        // userId가 일치하지 않고, 권한도 MASTER가 아닌 경우 예외처리
+        throw new RuntimeException("권한이 없는 사용자");
+    }
+
+}

--- a/com.flash.user/src/main/java/com/flash/user/application/service/util/UserMapper.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/util/UserMapper.java
@@ -1,4 +1,4 @@
-package com.flash.user.application.service.mapper;
+package com.flash.user.application.service.util;
 
 import com.flash.user.application.dto.request.JoinRequestDto;
 import com.flash.user.application.dto.response.JoinResponseDto;
@@ -32,7 +32,7 @@ public class UserMapper {
                 .build();
     }
 
-    public static UserResponseDto toVendorFrom(User user) {
+    public static UserResponseDto getNameFrom(User user) {
         return UserResponseDto.builder()
                 .name(user.getName())
                 .build();

--- a/com.flash.user/src/main/java/com/flash/user/domain/model/User.java
+++ b/com.flash.user/src/main/java/com/flash/user/domain/model/User.java
@@ -2,10 +2,7 @@ package com.flash.user.domain.model;
 
 import com.flash.base.jpa.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Where;
 
 @Getter
@@ -32,11 +29,14 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoleEnum role;
 
+    @Setter
     private String address;
 
+    @Setter
     @Column(unique = true, nullable = false)
     private String phone;
 
+    @Setter
     @Column(nullable = false)
     private String name;
 

--- a/com.flash.user/src/main/java/com/flash/user/domain/repository/UserRepository.java
+++ b/com.flash.user/src/main/java/com/flash/user/domain/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.flash.user.domain.repository;
 
 import com.flash.user.domain.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -15,4 +17,6 @@ public interface UserRepository {
     Optional<User> findById(Long userId);
 
     Optional<User> findByEmail(String email);
+
+    Page<User> findAll(Pageable pageable);
 }

--- a/com.flash.user/src/main/java/com/flash/user/infrastructure/repository/JpaUserRepository.java
+++ b/com.flash.user/src/main/java/com/flash/user/infrastructure/repository/JpaUserRepository.java
@@ -2,6 +2,8 @@ package com.flash.user.infrastructure.repository;
 
 import com.flash.user.domain.model.User;
 import com.flash.user.domain.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -17,4 +19,7 @@ public interface JpaUserRepository extends JpaRepository<User, Long>, UserReposi
     Optional<User> findById(Long userId);
 
     Optional<User> findByEmail(String email);
+
+    Page<User> findAll(Pageable pageable);
+
 }

--- a/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
+++ b/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
@@ -2,12 +2,13 @@ package com.flash.user.presentation.controller;
 
 import com.flash.user.application.dto.request.UpdateRequestDto;
 import com.flash.user.application.dto.response.UserInfoResponseDto;
+import com.flash.user.application.dto.response.UserResponseDto;
 import com.flash.user.application.service.UserService;
+import com.flash.user.application.service.util.UserAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j(topic = "User Controller")
@@ -17,29 +18,26 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserAuthService userAuthService;
 
     @PreAuthorize("isAuthenticated()")
-    @GetMapping("/self")
-    public ResponseEntity<UserInfoResponseDto> getUser() {
-        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
-
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserInfoResponseDto> getUser(@PathVariable String userId) {
+        userAuthService.verifyIdentity(userId);
         return ResponseEntity.ok(userService.getUserInfo(userId));
     }
 
     @PreAuthorize("isAuthenticated()")
-    @PatchMapping
-    public ResponseEntity<UserInfoResponseDto> updateUser(@RequestBody UpdateRequestDto updateRequestDto) {
-        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
-
-        return ResponseEntity.ok(userService.updateUser(userId, updateRequestDto));
-    }
-
-    @PreAuthorize("hasRole('MASTER')")
     @PatchMapping("/{userId}")
     public ResponseEntity<UserInfoResponseDto> updateUserByMaster(@PathVariable String userId, @RequestBody UpdateRequestDto updateRequestDto) {
-
+        userAuthService.verifyIdentity(userId);
         return ResponseEntity.ok(userService.updateUser(userId, updateRequestDto));
     }
 
-
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<UserResponseDto> deleteUser(@PathVariable String userId) {
+        userAuthService.verifyIdentity(userId);
+        return ResponseEntity.ok(userService.deleteUser(userId));
+    }
 }

--- a/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
+++ b/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
@@ -7,6 +7,7 @@ import com.flash.user.application.service.UserService;
 import com.flash.user.application.service.util.UserAuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -40,4 +41,16 @@ public class UserController {
         userAuthService.verifyIdentity(userId);
         return ResponseEntity.ok(userService.deleteUser(userId));
     }
+
+    @PreAuthorize("hasRole('MASTER')")
+    @GetMapping
+    public ResponseEntity<Page<UserInfoResponseDto>> getUserList(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @RequestParam("sort") String sortBy,
+            @RequestParam("isAsc") boolean isAsc) {
+
+        return ResponseEntity.ok(userService.getUserList(page - 1, size, sortBy, isAsc));
+    }
+
 }

--- a/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
+++ b/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.flash.user.presentation.controller;
 
+import com.flash.user.application.dto.request.UpdateRequestDto;
 import com.flash.user.application.dto.response.UserInfoResponseDto;
 import com.flash.user.application.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -7,9 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j(topic = "User Controller")
 @RestController
@@ -22,9 +21,16 @@ public class UserController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/self")
     public ResponseEntity<UserInfoResponseDto> getUser() {
-
         String userId = SecurityContextHolder.getContext().getAuthentication().getName();
 
         return ResponseEntity.ok(userService.getUserInfo(userId));
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping
+    public ResponseEntity<UserInfoResponseDto> updateUser(@RequestBody UpdateRequestDto updateRequestDto) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        return ResponseEntity.ok(userService.updateUser(userId, updateRequestDto));
     }
 }

--- a/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
+++ b/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.flash.user.presentation.controller;
+
+import com.flash.user.application.dto.response.UserInfoResponseDto;
+import com.flash.user.application.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "User Controller")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/self")
+    public ResponseEntity<UserInfoResponseDto> getUser() {
+
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        return ResponseEntity.ok(userService.getUserInfo(userId));
+    }
+}

--- a/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
+++ b/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserController.java
@@ -33,4 +33,13 @@ public class UserController {
 
         return ResponseEntity.ok(userService.updateUser(userId, updateRequestDto));
     }
+
+    @PreAuthorize("hasRole('MASTER')")
+    @PatchMapping("/{userId}")
+    public ResponseEntity<UserInfoResponseDto> updateUserByMaster(@PathVariable String userId, @RequestBody UpdateRequestDto updateRequestDto) {
+
+        return ResponseEntity.ok(userService.updateUser(userId, updateRequestDto));
+    }
+
+
 }

--- a/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserInternalController.java
+++ b/com.flash.user/src/main/java/com/flash/user/presentation/controller/UserInternalController.java
@@ -27,7 +27,7 @@ public class UserInternalController {
     @GetMapping("/{userId}")
     public UserResponseDto getUserInfo(@PathVariable String userId) {
         log.info("Getting user: {}", userId);
-        return userService.getUserInfo(userId);
+        return userService.getUserInfoForVendor(userId);
     }
 
     @PostMapping("/verify")


### PR DESCRIPTION
## 이슈 번호

Issue📌: #57 #58 #60 #59  

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용

처음 올린 pr에서는 관리자 엔드포인트를 따로 염두하고 만들었으나,
리팩토링을 하여 하나의 엔드포인트로 각각 crud 로직을 구현하였습니다.

또한 baseEntity에서 파라미터로 userId를 받는 부분 수정하였으니
확인하시고 이에 맞게 수정해주시면 감사하겠습니다.

- 회원 정보 조회, 수정, 삭제 구현
- 본인인지 확인
- 본인이 아니라면 관리자 권한인지 확인
- 위 2개의 인증, 인가는 application.service.util에 UserAuthService만들어서 진행
- baseEntity에서 deletedBy를 SecurityContext에서 가져올 수 있도록 수정
- MASTER권한 회원 정보 전체 조회 엔드포인트 구현.

## 닫을 이슈

close #57 #58 #60 #59 

---

## 다음 할 일
관리작 권한 회원 전체 조회

## 질문 사항

**💬질문 내용**

**🔴 이건 반드시 확인해 주세요!**
