### PR TITLE
API 요청 최적화 (Gateway 캐싱 처리)

### DIFF
--- a/com.flash.auth/src/main/java/com/flash/auth/application/service/AuthService.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/application/service/AuthService.java
@@ -50,8 +50,9 @@ public class AuthService {
      */
     public AuthResponseDto verify(HttpHeaders headers) {
         String accessToken = jwtUtil.getAccessTokenFromHeader(headers);
-        if (accessToken != null && !jwtUtil.isValidateToken(accessToken) || !jwtUtil.isNotExpiredAccessToken(accessToken)) {
+        if (accessToken != null && !jwtUtil.isValidateToken(accessToken)) {
             // TODO: 커스텀 예외 던지기
+            // 근데 발생하는 예외에 대해서 각각 ErrorCode를 정의하려면, throw를 JwtUtil에서 해야할 것 같은데..?
             throw new RuntimeException("Invalid access token");
         }
         String userIdFromAccessToken = jwtUtil.getUserIdFromAccessToken(accessToken);

--- a/com.flash.auth/src/main/java/com/flash/auth/application/service/util/JwtUtil.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/application/service/util/JwtUtil.java
@@ -95,28 +95,14 @@ public class JwtUtil {
         try {
             Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
             return true;
-        } catch (UnsupportedJwtException e) {
-            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다. 사용자 ID: {}", getUserIdFromAccessToken(token));
-        } catch (MalformedJwtException | SecurityException e) {
-            log.error("Invalid JWT token, 유효하지 않은 JWT token 입니다. 사용자 ID: {}", getUserIdFromAccessToken(token));
-        } catch (IllegalArgumentException e) {
-            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다. 사용자 ID: {}", getUserIdFromAccessToken(token));
-        }
-        return false;
-    }
-
-    /**
-     * Access Token 만료되었는지 검증하는 메서드
-     *
-     * @param token
-     * @return
-     */
-    public Boolean isNotExpiredAccessToken(String token) {
-        try {
-            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
-            return true;
         } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token, 만료된 Access 토큰입니다. 사용자 ID: {}", getUserIdFromAccessToken(token));
+            log.error("Expired JWT token, 만료된 Access 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (MalformedJwtException | SecurityException e) {
+            log.error("Invalid JWT token, 유효하지 않은 JWT token 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
         }
         return false;
     }

--- a/com.flash.auth/src/main/java/com/flash/auth/presentation/controller/AuthController.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/presentation/controller/AuthController.java
@@ -32,11 +32,11 @@ public class AuthController {
         return ResponseEntity.ok(authService.join(joinRequestDto));
     }
 
-    // 로그인 요청을 계속 보내지 못하도록 막는 방법은?
+    // TODO: 로그인 요청을 계속 보내지 못하도록 막는 방법은?
     // @PreAuthorize("isAnonymous()")
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginRequestDto loginRequestDto, HttpServletResponse response) {
-        // refresh token을 redis에 저장할 예정인데, 그게 있으면 return ?
+        // TODO: refresh token을 redis에 저장할 예정인데, 그게 있으면 return ?
         LoginResponseDto loginResponseDto = authService.attemptAuthentication(loginRequestDto);
         response.addHeader(AUTHORIZATION_HEADER, loginResponseDto.accessToken());
         response.addCookie(cookieUtil.createCookieWithRefreshToken(loginResponseDto.refreshToken()));

--- a/com.flash.base/src/main/java/com/flash/base/jpa/BaseEntity.java
+++ b/com.flash.base/src/main/java/com/flash/base/jpa/BaseEntity.java
@@ -38,7 +38,6 @@ public class BaseEntity implements Serializable {
 
     private boolean isDeleted = false;
 
-    // TODO: deletedBy는 Security 구현 후 수정
     public void delete() {
         this.deletedAt = LocalDateTime.now();
         this.deletedBy = SecurityContextHolder.getContext().getAuthentication().getName();

--- a/com.flash.gateway/build.gradle
+++ b/com.flash.gateway/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/com.flash.gateway/src/main/java/com/flash/gateway/config/CacheConfig.java
+++ b/com.flash.gateway/src/main/java/com/flash/gateway/config/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.flash.gateway.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(
+            RedisConnectionFactory redisConnectionFactory // RedisTemplate과 같이 Redis와의 연결정보가 구성돼야 함
+    ) {
+        // 사용자 데이터의 TTL을 Access Token 보다 조금 짧게 설정(9분)
+        RedisCacheConfiguration userDataCacheConfig = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(9))
+                .computePrefixWith(CacheKeyPrefix.simple())
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(RedisSerializer.json())
+                );
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .withCacheConfiguration("userInfo", userDataCacheConfig)
+                .build();
+    }
+}

--- a/com.flash.gateway/src/main/java/com/flash/gateway/filter/TokenValidationFilter.java
+++ b/com.flash.gateway/src/main/java/com/flash/gateway/filter/TokenValidationFilter.java
@@ -1,6 +1,9 @@
 package com.flash.gateway.filter;
 
-import com.flash.gateway.util.AuthResponseDto;
+import com.flash.gateway.service.CacheService;
+import com.flash.gateway.util.AuthUtil;
+import com.flash.gateway.util.dto.AuthResponseDto;
+import com.flash.gateway.util.dto.UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -12,51 +15,91 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 @Slf4j(topic = "Token Validation Filter")
 @Component
 @RequiredArgsConstructor
 public class TokenValidationFilter implements GatewayFilter {
 
     private final WebClient.Builder webClientBuilder;
+    private final CacheService cacheService;
+
+    // TODO: 로그 지우기, Mono, Flux 동작 방식 파악. switchIfEmpty()문 사용했을 때 empty()가 넘어오는 이유 파악
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         // 요청에서 Authorization 헤더 가져오기
         HttpHeaders headers = exchange.getRequest().getHeaders();
+        String bearerAccessToken = headers.getFirst(HttpHeaders.AUTHORIZATION);
 
         // 토큰이 없는 경우, 인증을 바로 실패 처리
-        if (headers.getFirst(HttpHeaders.AUTHORIZATION) == null) {
+        if (bearerAccessToken == null) {
             // TODO: 커스텀 예외로 변경
             return Mono.error(new RuntimeException("Authorization header is missing"));
         }
-        // TODO: 헤더에서 Access Token을 추출하여 클레임의 값 decoding.
+        // 헤더에서 Access Token을 추출하여 클레임의 값 decoding.
+        String accessTokenFromHeader = AuthUtil.getAccessTokenFromHeader(bearerAccessToken);
+        String jwtPayload = AuthUtil.decodeJwtPayload(accessTokenFromHeader);
+        UserInfo userInfoFromPayload = AuthUtil.extractUserInfoFromPayload(jwtPayload);
 
-        // TODO: 위에서 뽑은 값을 키로 캐싱된 클레임이 있는지 조회. 키 값을 뭐로 할지만 잘 정하면 될 듯!
+        return Mono.justOrEmpty(cacheService.getUserById(userInfoFromPayload.id()))
+                // 캐시된 데이터가 존재하고, 토큰과 role의 값이 같으면 라우팅 처리
+                .flatMap(cachedUserInfo -> {
+                    if (cachedUserInfo == null) {
+                        log.info("Cache miss: No cached user info found for userId {}", userInfoFromPayload.id());
+                        return sendAuthRequestAndCache(exchange, chain, bearerAccessToken, headers);
+                    }
+                    boolean accessTokenMatches = cachedUserInfo.accessToken().equals(bearerAccessToken);
+                    boolean roleMatches = cachedUserInfo.role().equals(userInfoFromPayload.role());
+                    boolean userIdMatches = cachedUserInfo.id().equals(userInfoFromPayload.id());
 
-        // TODO: 키-값이 맞으면, return(클라이언트 요청의 엔드포인트로 라우팅)
+                    if (accessTokenMatches && roleMatches && userIdMatches) {
+                        log.info("Cache hit: Cached user info matches for userId {}", cachedUserInfo.id());
+                        ServerHttpRequest request = AuthUtil.addHeader(exchange, cachedUserInfo);
+                        return chain.filter(exchange.mutate().request(request).build())
+                                .doOnSuccess(success -> log.info("Request successfully routed for userId {}", cachedUserInfo.id()))
+                                .then();  // Void 타입으로 반환하도록 수정
+                    } else {
+                        log.info("Cache miss: Cache info does not match for userId {}. AccessTokenMatches: {}, RoleMatches: {}, UserIdMatches: {}",
+                                cachedUserInfo.id(), accessTokenMatches, roleMatches, userIdMatches);
+                        return sendAuthRequestAndCache(exchange, chain, bearerAccessToken, headers);
+                    }
+                });
+    }
 
-        // 맞지 않으면, WebClient로 Auth 서버로 인증 요청 보내기
+    private Mono<Void> sendAuthRequestAndCache(ServerWebExchange exchange, GatewayFilterChain chain,
+                                               String bearerAccessToken, HttpHeaders headers) {
         return webClientBuilder.build()
                 .post()
-                .uri("lb://AUTH/api/auth/verify") // Auth 서버에 토큰 검증 요청
-                .headers(httpHeaders -> httpHeaders.addAll(headers)) // 기존 헤더 전달
+                .uri("lb://AUTH/api/auth/verify")
+                // TODO: 기존에는 headers를 그대로 전달했는데 문제가 발생했었음. 원인 파악 확실히!!!
+                // 조회 시에는 문제가 없었으나, get요청 이외의 요청에서는 1번 200ok되면 2번째는 에러가 발생했음
+                .headers(httpHeaders -> {
+                    httpHeaders.set(HttpHeaders.AUTHORIZATION, headers.getFirst(HttpHeaders.AUTHORIZATION));
+                    httpHeaders.set(HttpHeaders.CONTENT_TYPE, headers.getFirst(HttpHeaders.CONTENT_TYPE));
+                    httpHeaders.set(HttpHeaders.ACCEPT, headers.getFirst(HttpHeaders.ACCEPT));
+                })
                 .retrieve()
                 .bodyToMono(AuthResponseDto.class)
-                .flatMap(userInfo -> {
-                    log.info("userId: " + userInfo.id());
-                    log.info("role: " + userInfo.role());
+                .timeout(Duration.ofSeconds(2))
+                .flatMap(authResponseDto -> {
+                    log.info("userId: {}", authResponseDto.id());
+                    log.info("role: {}", authResponseDto.role());
 
-                    // TODO: 받아온 데이터 캐싱 처리
-
-
-                    // AuthResponseDto에서 id와 role을 추출하고 헤더에 추가
-                    ServerHttpRequest request = exchange.getRequest().mutate()
-                            .header("X-User-ID", userInfo.id())
-                            .header("X-User-Role", userInfo.role())
+                    UserInfo user = UserInfo.builder()
+                            .id(authResponseDto.id())
+                            .role(authResponseDto.role())
+                            .accessToken(bearerAccessToken)
                             .build();
-                    // 헤더에 userId와 role을 추가한 새로운 요청으로 필터 체인 계속 진행
+
+                    // 캐시에 저장
+                    cacheService.saveUserInfo(authResponseDto.id(), user);
+                    // 헤더에 추가
+                    ServerHttpRequest request = AuthUtil.addHeader(exchange, user);
                     return chain.filter(exchange.mutate().request(request).build());
                 })
+                .then()  // Void 타입으로 반환하도록 수정
                 .doOnError(error -> log.error("Error during token validation: {}", error.getMessage()));
     }
 }

--- a/com.flash.gateway/src/main/java/com/flash/gateway/service/CacheService.java
+++ b/com.flash.gateway/src/main/java/com/flash/gateway/service/CacheService.java
@@ -1,0 +1,21 @@
+package com.flash.gateway.service;
+
+import com.flash.gateway.util.dto.UserInfo;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CacheService {
+
+    @Cacheable(value = "userInfo", key = "#userId", unless = "#result == null")
+    public UserInfo getUserById(String userId) {
+        // 캐시 미스 시 null 반환
+        return null;
+    }
+
+    @CachePut(value = "userInfo", key = "#userId")
+    public UserInfo saveUserInfo(String userId, UserInfo userInfo) {
+        return userInfo;
+    }
+}

--- a/com.flash.gateway/src/main/java/com/flash/gateway/util/AuthUtil.java
+++ b/com.flash.gateway/src/main/java/com/flash/gateway/util/AuthUtil.java
@@ -1,0 +1,64 @@
+package com.flash.gateway.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flash.gateway.util.dto.UserInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.util.Base64;
+
+@Slf4j(topic = "Cache Util")
+@Component
+public class AuthUtil {
+
+    public static String getAccessTokenFromHeader(String bearerToken) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7).trim();
+        }
+        return null;
+    }
+
+    public static String decodeJwtPayload(String token) {
+        String[] parts = token.split("\\."); // JWT는 '.'으로 나뉨
+        String payload = parts[1]; // 두 번째 부분이 페이로드
+        return new String(Base64.getDecoder().decode(payload));
+    }
+
+    public static UserInfo extractUserInfoFromPayload(String payload) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            JsonNode payloadNode = objectMapper.readTree(payload);
+
+            String id = payloadNode.has("userId") ? payloadNode.get("userId").asText() : null;
+            String role = payloadNode.has("auth") ? payloadNode.get("auth").asText() : null;
+
+            if (id == null || role == null) {
+                // 필요한 필드가 없는 경우에 대한 처리
+                log.error("Invalid payload");
+                // TODO: 커스텀 예외 던지기
+//                throw new InvalidPayloadException("Invalid payload: missing required fields.");
+            }
+
+            return UserInfo.builder().id(id).role(role).build();
+
+        } catch (JsonProcessingException e) {
+            // TODO: 커스텀 예외?
+            log.error("Failed to parse payload");
+            throw new RuntimeException(e);
+//            throw new InvalidPayloadException("Failed to parse JWT payload", e);
+        }
+    }
+
+    public static ServerHttpRequest addHeader(ServerWebExchange exchange, UserInfo userInfo) {
+        return exchange.getRequest().mutate()
+                .header("X-User-ID", userInfo.id())
+                .header("X-User-Role", userInfo.role())
+                .build();
+    }
+
+}

--- a/com.flash.gateway/src/main/java/com/flash/gateway/util/dto/AuthResponseDto.java
+++ b/com.flash.gateway/src/main/java/com/flash/gateway/util/dto/AuthResponseDto.java
@@ -1,4 +1,4 @@
-package com.flash.gateway.util;
+package com.flash.gateway.util.dto;
 
 public record AuthResponseDto(
         String id,

--- a/com.flash.gateway/src/main/java/com/flash/gateway/util/dto/UserInfo.java
+++ b/com.flash.gateway/src/main/java/com/flash/gateway/util/dto/UserInfo.java
@@ -1,0 +1,11 @@
+package com.flash.gateway.util.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserInfo(
+        String id,
+        String role,
+        String accessToken
+) {
+}

--- a/com.flash.gateway/src/main/resources/application.yml
+++ b/com.flash.gateway/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
         locator:
           enabled: true
           lower-case-service-id: true
+  data:
+    redis:
+      host: ${REDIS_DOMAIN}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
 eureka:
   client:


### PR DESCRIPTION
## 이슈 번호

Issue📌: #90 

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용

- [x] 게이트웨이 Redis의존성 및 Config설정(캐싱 TTL은 9분으로 설정)
- [x] 헤더에서 토큰을 꺼내오는 로직, 토큰에서 payload를 꺼내오는 로직 등이 있는 AuthUtil 클래스 추가
- [x] Redis crud를 위한 CacheService 클래스 추가
- [x] 로그인 이후 처음 요청은 Auth서비스로 토큰 유효성 검사를 시키고 Gateway에서 캐싱처리
- [x] 이후 요청에 대해서는 캐싱된 데이터를 이용해 라우팅을 하여 Auth서비스로의 요청 수를 줄였음

## 닫을 이슈

close #90 

---

## 다음 할 일
커스텀 예외처리
알람 서비스

## 질문 사항

**💬질문 내용**

**🔴 이건 반드시 확인해 주세요!**
