### PR TITLE
User 모듈 커스텀 예외 처리 및 FeignClient 예외처리 추가

### DIFF
--- a/com.flash.auth/build.gradle
+++ b/com.flash.auth/build.gradle
@@ -1,4 +1,8 @@
 dependencies {
+    implementation(project(':base')) {
+        // Spring Security 관련 의존성 제외
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-security'
+    }
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
@@ -8,6 +12,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.postgresql:postgresql'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/com.flash.auth/src/main/java/com/flash/auth/AuthApplication.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/AuthApplication.java
@@ -3,9 +3,11 @@ package com.flash.auth;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.ComponentScan;
 
 @EnableFeignClients
 @SpringBootApplication
+@ComponentScan(basePackages = {"com.flash.base.exception", "com.flash.base.jpa", "com.flash.auth"})
 public class AuthApplication {
 
     public static void main(String[] args) {

--- a/com.flash.auth/src/main/java/com/flash/auth/infrastructure/client/UserFeignClient.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/infrastructure/client/UserFeignClient.java
@@ -5,11 +5,12 @@ import com.flash.auth.application.dto.request.LoginRequestDto;
 import com.flash.auth.application.dto.response.JoinResponseDto;
 import com.flash.auth.application.dto.response.LoginResponseDto;
 import com.flash.auth.application.service.FeignClientService;
+import com.flash.auth.infrastructure.configuration.FeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "user")
+@FeignClient(name = "user", configuration = FeignConfig.class)
 public interface UserFeignClient extends FeignClientService {
     @PostMapping("/api/internal/users/save")
     JoinResponseDto saveUser(@RequestBody JoinRequestDto joinRequestDto);

--- a/com.flash.auth/src/main/java/com/flash/auth/infrastructure/configuration/FeignConfig.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/infrastructure/configuration/FeignConfig.java
@@ -1,0 +1,15 @@
+package com.flash.auth.infrastructure.configuration;
+
+import com.flash.auth.infrastructure.exception.CustomErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new CustomErrorDecoder();
+    }
+}

--- a/com.flash.auth/src/main/java/com/flash/auth/infrastructure/exception/ClientErrorCode.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/infrastructure/exception/ClientErrorCode.java
@@ -1,0 +1,34 @@
+package com.flash.auth.infrastructure.exception;
+
+import com.flash.base.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ClientErrorCode implements ErrorCode {
+
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 요청 데이터를 확인해 주세요."),
+    DUPLICATED_REQUEST(HttpStatus.CONFLICT, "중복된 데이터가 있습니다. 다시 시도해 주세요"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 리소스에 접근할 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "현재 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해 주세요."),
+    UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 오류가 발생했습니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+
+    ClientErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/com.flash.auth/src/main/java/com/flash/auth/infrastructure/exception/CustomErrorDecoder.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/infrastructure/exception/CustomErrorDecoder.java
@@ -1,0 +1,21 @@
+package com.flash.auth.infrastructure.exception;
+
+import com.flash.base.exception.CustomException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class CustomErrorDecoder implements ErrorDecoder {
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        return switch (response.status()) {
+            case 400 -> new CustomException(ClientErrorCode.BAD_REQUEST);
+            case 403 -> new CustomException(ClientErrorCode.FORBIDDEN);
+            case 404 -> new CustomException(ClientErrorCode.RESOURCE_NOT_FOUND);
+            case 409 -> new CustomException(ClientErrorCode.DUPLICATED_REQUEST);
+            case 500 -> new CustomException(ClientErrorCode.INTERNAL_SERVER_ERROR);
+            case 503 -> new CustomException(ClientErrorCode.SERVICE_UNAVAILABLE);
+
+            default -> new CustomException(ClientErrorCode.UNEXPECTED_ERROR);
+        };
+    }
+}

--- a/com.flash.user/src/main/java/com/flash/user/application/service/util/UserAuthService.java
+++ b/com.flash.user/src/main/java/com/flash/user/application/service/util/UserAuthService.java
@@ -1,13 +1,17 @@
 package com.flash.user.application.service.util;
 
+import com.flash.base.exception.CustomException;
+import com.flash.user.domain.exception.UserErrorCode;
 import com.flash.user.domain.model.RoleEnum;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 
+@Slf4j(topic = "User Auth Service")
 @Component
 @RequiredArgsConstructor
 public class UserAuthService {
@@ -28,10 +32,9 @@ public class UserAuthService {
                 return;  // MASTER 권한이면 return
             }
         }
-
-        // TODO: 커스텀 예외
         // userId가 일치하지 않고, 권한도 MASTER가 아닌 경우 예외처리
-        throw new RuntimeException("권한이 없는 사용자");
+        log.error("access denied");
+        throw new CustomException(UserErrorCode.ACCESS_DENIED);
     }
 
 }

--- a/com.flash.user/src/main/java/com/flash/user/domain/exception/UserErrorCode.java
+++ b/com.flash.user/src/main/java/com/flash/user/domain/exception/UserErrorCode.java
@@ -1,0 +1,32 @@
+package com.flash.user.domain.exception;
+
+import com.flash.base.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorCode implements ErrorCode {
+
+    DUPLICATED_PHONE(HttpStatus.CONFLICT, "휴대폰 번호가 중복됩니다."),
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "E-Mail이 중복됩니다."),
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "올바른 권한 코드를 입력하세요"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    UserErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/com.flash.user/src/main/java/com/flash/user/domain/model/RoleEnum.java
+++ b/com.flash.user/src/main/java/com/flash/user/domain/model/RoleEnum.java
@@ -1,5 +1,7 @@
 package com.flash.user.domain.model;
 
+import com.flash.base.exception.CustomException;
+import com.flash.user.domain.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -11,8 +13,6 @@ public enum RoleEnum {
     CUSTOMER(Authority.CUSTOMER);
 
     private final String authority;
-
-    // TODO: 여기서 예외를 던지는 것이 적절한가? Optional?
 
     /**
      * roleCode에 따른 RoleEnum을 반환
@@ -26,7 +26,7 @@ public enum RoleEnum {
                 return role;
             }
         }
-        throw new IllegalArgumentException("Invalid role code: " + roleCode);
+        throw new CustomException(UserErrorCode.INVALID_ROLE);
     }
 
     public String getAuthority() {


### PR DESCRIPTION
1. User 모듈에서 발생하는 예외들을 커스텀 예외로 수정.
2. 회원가입 시, 유효성 검사 시
Auth에서 User로 FeignClient요청을 보내느데,
User에서 발생하는 예외가 Auth로 전파되지 않는 문제 해결
