### PR TITLE
refactor: 플래시 세일 서비스 버그바운티 대비 코드 수정

### DIFF
--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/dto/request/ProductStatusUpdateDto.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/dto/request/ProductStatusUpdateDto.java
@@ -1,0 +1,6 @@
+package com.flash.flashsale.application.dto.request;
+
+public record ProductStatusUpdateDto(
+    String status
+) {
+}

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/dto/request/ProductStockIncreaseRequestDto.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/dto/request/ProductStockIncreaseRequestDto.java
@@ -1,0 +1,6 @@
+package com.flash.flashsale.application.dto.request;
+
+public record ProductStockIncreaseRequestDto(
+    Integer quantity
+) {
+}

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/dto/response/ProductStockIncreaseResponseDto.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/dto/response/ProductStockIncreaseResponseDto.java
@@ -1,0 +1,9 @@
+package com.flash.flashsale.application.dto.response;
+
+import java.util.UUID;
+
+public record ProductStockIncreaseResponseDto(
+    UUID productId,
+    int status // 오타인가
+) {
+}

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FeignClientService.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FeignClientService.java
@@ -15,11 +15,9 @@ public interface FeignClientService {
 
     void decreaseProductStock(UUID productId, Integer stock);
 
-    void startSale(List<UUID> productId);
-
-    void endSale(List<UUID> productIdList);
-
     void increaseProductStock(List<ProductStockRequestDto> productStocks);
 
     ProductStockIncreaseResponseDto increaseOneProductStock(UUID productId, Integer stock);
+
+    ProductResponseDto updateProductStatus(UUID productId, String status);
 }

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FeignClientService.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FeignClientService.java
@@ -2,6 +2,7 @@ package com.flash.flashsale.application.service;
 
 import com.flash.flashsale.application.dto.request.ProductStockRequestDto;
 import com.flash.flashsale.application.dto.response.ProductResponseDto;
+import com.flash.flashsale.application.dto.response.ProductStockIncreaseResponseDto;
 
 import java.util.List;
 import java.util.Map;
@@ -19,4 +20,6 @@ public interface FeignClientService {
     void endSale(List<UUID> productIdList);
 
     void increaseProductStock(List<ProductStockRequestDto> productStocks);
+
+    ProductStockIncreaseResponseDto increaseOneProductStock(UUID productId, Integer stock);
 }

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FlashSaleProductService.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FlashSaleProductService.java
@@ -17,6 +17,7 @@ import com.flash.flashsale.domain.model.FlashSaleProduct;
 import com.flash.flashsale.domain.model.FlashSaleProductStatus;
 import com.flash.flashsale.domain.repository.FlashSaleProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -33,6 +34,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class FlashSaleProductService {
 
     private final FlashSaleService flashSaleService;
@@ -71,7 +73,7 @@ public class FlashSaleProductService {
         validAvailableDateTime(flashSaleProductUpdateRequestDto.startTime(), flashSaleProductUpdateRequestDto.endTime());
 
         FlashSaleProduct flashSaleProduct = getFlashSaleProductByStatus(flashSaleProductId, List.of(FlashSaleProductStatus.PENDING, FlashSaleProductStatus.APPROVE)).orElseThrow(
-                () -> new CustomException(FlashSaleProductErrorCode.NOT_AVAILABLE_UPDATE)
+            () -> new CustomException(FlashSaleProductErrorCode.NOT_AVAILABLE_UPDATE)
         );
 
         FlashSale flashSale = flashSaleService.existFlashSale(flashSaleProduct.getFlashSale().getId());
@@ -135,7 +137,7 @@ public class FlashSaleProductService {
         validAdmin();
 
         FlashSaleProduct flashSaleProduct = getFlashSaleProductByStatus(flashSaleProductId, List.of(FlashSaleProductStatus.PENDING)).orElseThrow(
-                () -> new CustomException(FlashSaleProductErrorCode.IS_NOT_PENDING)
+            () -> new CustomException(FlashSaleProductErrorCode.IS_NOT_PENDING)
         );
 
         if (flashSaleProduct.getStartTime().isBefore(LocalDateTime.now().plusMinutes(30))) {
@@ -151,13 +153,14 @@ public class FlashSaleProductService {
     public String refuse(UUID flashSaleProductId) {
         validAdmin();
 
-        FlashSaleProduct flashSaleProduct = getFlashSaleProductByStatus(flashSaleProductId, List.of(FlashSaleProductStatus.PENDING, FlashSaleProductStatus.APPROVE)).orElseThrow(
-                () -> new CustomException(FlashSaleProductErrorCode.NOT_AVAILABLE_REFUSE)
+        FlashSaleProduct flashSaleProduct = getFlashSaleProductByStatus(flashSaleProductId, List.of(FlashSaleProductStatus.PENDING)).orElseThrow(
+            () -> new CustomException(FlashSaleProductErrorCode.NOT_AVAILABLE_REFUSE)
         );
 
         flashSaleProduct.refuse();
-        increaseProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
 
+//        increaseProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());   임시로 V2버전 사용
+        increaseProductStockV2(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
         return "승인 거절 되었습니다.";
     }
 
@@ -166,14 +169,15 @@ public class FlashSaleProductService {
         validAuthority();
 
         FlashSaleProduct flashSaleProduct = getFlashSaleProductByStatus(flashSaleProductId, List.of(FlashSaleProductStatus.ONSALE)).orElseThrow(
-                () -> new CustomException(FlashSaleProductErrorCode.IS_ON_SALE_DELETE)
+            () -> new CustomException(FlashSaleProductErrorCode.IS_ON_SALE_DELETE)
         );
 
         validAvailableFlashSale(flashSaleProduct);
         feignClientService.endSale(List.of(flashSaleProduct.getProductId()));
 
         flashSaleProduct.endSale();
-        increaseProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
+        //        increaseProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());   임시로 V2버전 사용
+        increaseProductStockV2(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
 
         return "세일이 종료되었습니다.";
     }
@@ -185,7 +189,10 @@ public class FlashSaleProductService {
         FlashSaleProduct flashSaleProduct = availableFlashSaleProduct(flashSaleProductId);
         flashSaleProduct.delete();
 
-        increaseProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
+        //        increaseProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());   임시로 V2버전 사용
+        if (!flashSaleProduct.getStatus().equals(FlashSaleProductStatus.REFUSE)) {
+            increaseProductStockV2(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
+        }
 
         return "삭제되었습니다.";
     }
@@ -206,14 +213,18 @@ public class FlashSaleProductService {
         //실행시간에 따른 오차에 대응하기 위해 임의로 5분씩 설정하였습니다.
 
         List<FlashSaleProduct> flashSaleProductList = flashSaleProductRepository.findAllByStatusAndEndTimeBetweenAndIsDeletedFalse(FlashSaleProductStatus.ONSALE, fiveMinutesAgo, fiveMinutesLater);
-        List<UUID> productIdList = flashSaleProductList.stream().map(FlashSaleProduct::getProductId).distinct().toList();
-        List<ProductStockRequestDto> productStocks = flashSaleProductList.stream().map(flashSaleProduct -> flashSaleProductMapper.convertToProductStockResponseDto(flashSaleProduct.getProductId(), flashSaleProduct.getStock())).toList();
+//        List<UUID> productIdList = flashSaleProductList.stream().map(FlashSaleProduct::getProductId).distinct().toList();
+//        List<ProductStockRequestDto> productStocks = flashSaleProductList.stream().map(flashSaleProduct -> flashSaleProductMapper.convertToProductStockResponseDto(flashSaleProduct.getProductId(), flashSaleProduct.getStock())).toList();
 
-        feignClientService.endSale(productIdList);
-        feignClientService.increaseProductStock(productStocks);
+//        feignClientService.endSale(productIdList);
+//        feignClientService.increaseProductStock(productStocks);
 
-
-        flashSaleProductList.forEach(FlashSaleProduct::endSale);
+//        flashSaleProductList.forEach(FlashSaleProduct::endSale);  V2버전으로 임시 변경
+        flashSaleProductList.forEach(flashSaleProduct -> {
+                feignClientService.increaseOneProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
+                flashSaleProduct.endSale();
+            }
+        );
     }
 
     @Transactional
@@ -224,7 +235,13 @@ public class FlashSaleProductService {
         LocalDateTime fiveMinutesLater = currentDateTime.plusMinutes(35);
         //실행시간에 따른 오차에 대응하기 위해 임의로 5분씩 설정하였습니다.
 
-        flashSaleProductRepository.findAllByStatusAndEndTimeBetweenAndIsDeletedFalse(FlashSaleProductStatus.PENDING, fiveMinutesAgo, fiveMinutesLater).forEach(FlashSaleProduct::refuse);
+        List<FlashSaleProduct> flashSaleProductList = flashSaleProductRepository.findAllByStatusAndEndTimeBetweenAndIsDeletedFalse(FlashSaleProductStatus.PENDING, fiveMinutesAgo, fiveMinutesLater);
+
+        flashSaleProductList.forEach(flashSaleProduct -> {
+                feignClientService.increaseOneProductStock(flashSaleProduct.getProductId(), flashSaleProduct.getStock());
+                flashSaleProduct.refuse();
+            }
+        );
     }
 
     @Transactional
@@ -244,7 +261,7 @@ public class FlashSaleProductService {
 
     private FlashSaleProduct existFlashSaleProduct(UUID flashSaleProductId) {
         return flashSaleProductRepository.findByIdAndIsDeletedFalse(flashSaleProductId).orElseThrow(
-                () -> new CustomException(FlashSaleProductErrorCode.NOT_FOUND)
+            () -> new CustomException(FlashSaleProductErrorCode.NOT_FOUND)
         );
     }
 
@@ -387,12 +404,12 @@ public class FlashSaleProductService {
 
     private String getAuthority() {
         return SecurityContextHolder.getContext().getAuthentication()
-                .getAuthorities()
-                .stream()
-                .findFirst()
-                .orElseThrow(() ->
-                        new CustomException(FlashSaleProductErrorCode.INVALID_PERMISSION_REQUEST))
-                .getAuthority();
+            .getAuthorities()
+            .stream()
+            .findFirst()
+            .orElseThrow(() ->
+                new CustomException(FlashSaleProductErrorCode.INVALID_PERMISSION_REQUEST))
+            .getAuthority();
     }
 
     public String getCurrentUserId() {
@@ -403,7 +420,7 @@ public class FlashSaleProductService {
 
     private void validAuthority() {
         String authority = SecurityContextHolder.getContext().getAuthentication()
-                .getAuthorities().toString();
+            .getAuthorities().toString();
 
         if (authority.equals("ROLE_CUSTOMER")) {
             throw new CustomException(FlashSaleProductErrorCode.INVALID_PERMISSION_REQUEST);
@@ -456,6 +473,11 @@ public class FlashSaleProductService {
         feignClientService.increaseProductStock(List.of(productStocks));
     }
 
+    @Transactional
+    public void increaseProductStockV2(UUID productId, Integer stock) {
+        feignClientService.increaseOneProductStock(productId, stock);
+    }
+
     private ProductResponseDto getProductInfo(UUID productId) {
         return feignClientService.getProductInfo(productId);
     }
@@ -465,7 +487,8 @@ public class FlashSaleProductService {
         List<FlashSaleProduct> flashSaleProductList = flashSaleProductRepository.findAllByProductIdAndIsDeletedFalse(productId);
 
         Integer totalStock = flashSaleProductList.stream().mapToInt(FlashSaleProduct::getStock).sum();
-        increaseProductStock(productId, totalStock);
+//        increaseProductStock(productId, totalStock);    임시로 V2버전 사용
+        increaseProductStockV2(productId, totalStock);
 
         flashSaleProductList.forEach(FlashSaleProduct::delete);
     }

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FlashSaleProductService.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/application/service/FlashSaleProductService.java
@@ -481,6 +481,10 @@ public class FlashSaleProductService {
     public void decreaseStock(UUID flashSaleProductId) {
         FlashSaleProduct flashSaleProduct = existFlashSaleProduct(flashSaleProductId);
 
+        if (flashSaleProduct.getStock() == 0) {
+            throw new CustomException(FlashSaleProductErrorCode.NOT_AVAILABLE_ORDER);
+        }
+
         flashSaleProduct.decreaseStock();
 
         if (flashSaleProduct.getStock() == 0) {

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/domain/exception/FlashSaleProductErrorCode.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/domain/exception/FlashSaleProductErrorCode.java
@@ -16,6 +16,7 @@ public enum FlashSaleProductErrorCode implements ErrorCode {
     NOT_AVAILABLE_UPDATE(HttpStatus.BAD_REQUEST, "승인 중이거나 승인 대기중인 플래시 세일 상품만 수정 할 수 있습니다."),
     NOT_AVAILABLE_REFUSE(HttpStatus.BAD_REQUEST, "승인 중이거나 승인 대기중인 플래시 세일 상품만 거절 할 수 있습니다."),
     NOT_AVAILABLE_PRICE(HttpStatus.BAD_REQUEST, "세일가격은 상품가격보다 낮을 수 없습니다."),
+    NOT_AVAILABLE_ORDER(HttpStatus.BAD_REQUEST, "재고가 없습니다."),
     IS_NOT_PENDING(HttpStatus.BAD_REQUEST, "승인 대기중인 플래시 세일 상품만 승인 할 수 있습니다."),
     IS_ON_SALE_DELETE(HttpStatus.BAD_REQUEST, "세일중인 플래시 세일 상품만 종료 할 수 있습니다."),
     IS_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "세일중이지 않은 플래시 세일 상품입니다."),

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/FeignClientServiceImpl.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/FeignClientServiceImpl.java
@@ -36,16 +36,6 @@ public class FeignClientServiceImpl implements FeignClientService {
     }
 
     @Override
-    public void startSale(List<UUID> productIds) {
-        vendorFeignClient.startSale(new ProductListRequestDto(productIds));
-    }
-
-    @Override
-    public void endSale(List<UUID> productIds) {
-        vendorFeignClient.endSale(new ProductListRequestDto(productIds));
-    }
-
-    @Override
     public void increaseProductStock(List<ProductStockRequestDto> productStocks) {
         vendorFeignClient.increaseProductStock(new ProductStockListRequestDto(productStocks));
     }
@@ -53,6 +43,11 @@ public class FeignClientServiceImpl implements FeignClientService {
     @Override
     public ProductStockIncreaseResponseDto increaseOneProductStock(UUID productId, Integer stock) {
         return vendorFeignClient.increaseOneProductStock(productId, new ProductStockIncreaseRequestDto(stock));
+    }
+
+    @Override
+    public ProductResponseDto updateProductStatus(UUID productId, String status) {
+        return vendorFeignClient.updateProductStatus(productId, new ProductStatusUpdateDto(status));
     }
 
     public List<ProductResponseDto> getProductInfoList(List<UUID> productIds) {

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/FeignClientServiceImpl.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/FeignClientServiceImpl.java
@@ -1,10 +1,8 @@
 package com.flash.flashsale.infrastructure.client;
 
-import com.flash.flashsale.application.dto.request.ProductListRequestDto;
-import com.flash.flashsale.application.dto.request.ProductStockDecreaseRequestDto;
-import com.flash.flashsale.application.dto.request.ProductStockListRequestDto;
-import com.flash.flashsale.application.dto.request.ProductStockRequestDto;
+import com.flash.flashsale.application.dto.request.*;
 import com.flash.flashsale.application.dto.response.ProductResponseDto;
+import com.flash.flashsale.application.dto.response.ProductStockIncreaseResponseDto;
 import com.flash.flashsale.application.service.FeignClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -50,6 +48,11 @@ public class FeignClientServiceImpl implements FeignClientService {
     @Override
     public void increaseProductStock(List<ProductStockRequestDto> productStocks) {
         vendorFeignClient.increaseProductStock(new ProductStockListRequestDto(productStocks));
+    }
+
+    @Override
+    public ProductStockIncreaseResponseDto increaseOneProductStock(UUID productId, Integer stock) {
+        return vendorFeignClient.increaseOneProductStock(productId, new ProductStockIncreaseRequestDto(stock));
     }
 
     public List<ProductResponseDto> getProductInfoList(List<UUID> productIds) {

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/VendorFeignClient.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/VendorFeignClient.java
@@ -1,9 +1,6 @@
 package com.flash.flashsale.infrastructure.client;
 
-import com.flash.flashsale.application.dto.request.ProductListRequestDto;
-import com.flash.flashsale.application.dto.request.ProductStockDecreaseRequestDto;
-import com.flash.flashsale.application.dto.request.ProductStockIncreaseRequestDto;
-import com.flash.flashsale.application.dto.request.ProductStockListRequestDto;
+import com.flash.flashsale.application.dto.request.*;
 import com.flash.flashsale.application.dto.response.ProductListResponseDto;
 import com.flash.flashsale.application.dto.response.ProductResponseDto;
 import com.flash.flashsale.application.dto.response.ProductStockDecreaseResponseDto;
@@ -40,9 +37,9 @@ public interface VendorFeignClient {
         @RequestBody ProductStockIncreaseRequestDto request
     );
 
-    @PatchMapping("/api/internal/products/start-sale")
-    void startSale(@RequestBody ProductListRequestDto request);
-
-    @PatchMapping("/api/internal/products/end-sale")
-    void endSale(@RequestBody ProductListRequestDto request);
+    @PatchMapping("/api/internal/products/{productId}")
+    ProductResponseDto updateProductStatus(
+        @PathVariable UUID productId,
+        @RequestBody ProductStatusUpdateDto request
+    );
 }

--- a/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/VendorFeignClient.java
+++ b/com.flash.flashsale/src/main/java/com/flash/flashsale/infrastructure/client/VendorFeignClient.java
@@ -2,10 +2,12 @@ package com.flash.flashsale.infrastructure.client;
 
 import com.flash.flashsale.application.dto.request.ProductListRequestDto;
 import com.flash.flashsale.application.dto.request.ProductStockDecreaseRequestDto;
+import com.flash.flashsale.application.dto.request.ProductStockIncreaseRequestDto;
 import com.flash.flashsale.application.dto.request.ProductStockListRequestDto;
 import com.flash.flashsale.application.dto.response.ProductListResponseDto;
 import com.flash.flashsale.application.dto.response.ProductResponseDto;
 import com.flash.flashsale.application.dto.response.ProductStockDecreaseResponseDto;
+import com.flash.flashsale.application.dto.response.ProductStockIncreaseResponseDto;
 import com.flash.flashsale.infrastructure.configuration.FeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +32,12 @@ public interface VendorFeignClient {
     @PatchMapping("/api/internal/products/stock/increase")
     void increaseProductStock(
             @RequestBody ProductStockListRequestDto request
+    );
+
+    @PatchMapping("/api/internal/products/{productId}/stock/increase")
+    ProductStockIncreaseResponseDto increaseOneProductStock(
+        @PathVariable UUID productId,
+        @RequestBody ProductStockIncreaseRequestDto request
     );
 
     @PatchMapping("/api/internal/products/start-sale")


### PR DESCRIPTION
플래시 세일 서비스 버그바운티 대비 코드 수정하였습니다.

### 상세 내용

플래시 세일 종료시 상품의 재고 증가 FeinClient dto 상품서비스의 dto로 임시 변경
플래시 세일 세일시작, 종료 시 상품의 상태 변경 FeinClient 상품서비스의 dto로 수정 // 성능향상을 위해 추후에 dto를 리스트로 변경 예정
자잘한 코드 누락 수정