### PR TITLE
Fix/auth

### DIFF
--- a/com.flash.auth/src/main/java/com/flash/auth/application/service/AuthService.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/application/service/AuthService.java
@@ -109,7 +109,7 @@ public class AuthService {
         // 화이트리스트에서 삭제 및 블랙리스트 처리
         cacheUtil.deleteAccessToken(jwtUtil.getUserIdFromRefreshToken(refreshToken));
         cacheUtil.setAccessTokenToBlackList(accessToken, AuthMapper.toUserInfo(jwtUtil.getUserIdFromRefreshToken(refreshToken), jwtUtil.getUserRoleFromRefreshToken(refreshToken), accessToken));
-        cacheUtil.deleteRefreshToken(refreshToken);
+        cacheUtil.deleteRefreshToken(jwtUtil.getUserIdFromRefreshToken(refreshToken));
 
         // Todo: 헤더 및 쿠키에서 삭제?
     }

--- a/com.flash.auth/src/main/java/com/flash/auth/application/service/AuthService.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/application/service/AuthService.java
@@ -36,6 +36,7 @@ public class AuthService {
 
     public LoginResponseDto attemptAuthentication(LoginRequestDto loginRequestDto) {
         LoginResponseDto loginResponseDto = feignClientService.verifyUserCredentials(loginRequestDto); // valid한 user가 아닐 때의 예외는 user서비스에서 처리
+        isSignedIn(loginResponseDto.id());
         return successfulAuthentication(loginResponseDto);
     }
 
@@ -112,5 +113,12 @@ public class AuthService {
         cacheUtil.deleteRefreshToken(jwtUtil.getUserIdFromRefreshToken(refreshToken));
 
         // Todo: 헤더 및 쿠키에서 삭제?
+    }
+
+
+    public void isSignedIn(String userId) {
+        if (cacheUtil.getValidAccessToken(userId) != null || cacheUtil.getValidRefreshToken(userId) != null) {
+            throw new CustomException(AuthErrorCode.ALREADY_SIGNED_IN_USER);
+        }
     }
 }

--- a/com.flash.auth/src/main/java/com/flash/auth/application/service/util/CacheUtil.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/application/service/util/CacheUtil.java
@@ -1,11 +1,13 @@
 package com.flash.auth.application.service.util;
 
 import com.flash.base.dto.UserInfo;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+@Slf4j(topic = "Cache Util")
 @Service
 public class CacheUtil {
 
@@ -48,6 +50,19 @@ public class CacheUtil {
     }
 
     /**
+     * Access Token 조회
+     *
+     * @param userId
+     * @return
+     */
+    @Cacheable(cacheNames = "accessTokenWhiteList", key = "#userId", unless = "#result == null")
+    public UserInfo getValidAccessToken(String userId) {
+        // 캐시 미스 시 null 반환
+        return null;
+    }
+
+
+    /**
      * Refresh Token 조회
      *
      * @param userId
@@ -64,14 +79,15 @@ public class CacheUtil {
      */
     @CacheEvict(cacheNames = "accessTokenWhiteList", key = "#userId")
     public void deleteAccessToken(String userId) {
+        log.info("로그아웃 되었습니다: {}", userId);
         // 캐시에서 해당 userId로 저장된 데이터를 삭제
     }
 
     /**
      * 화이트리스트 처리된 Refresh Token을 삭제
      */
-    @CacheEvict(cacheNames = "refreshTokenWhiteList", key = "#refreshToken")
-    public void deleteRefreshToken(String refreshToken) {
+    @CacheEvict(cacheNames = "refreshTokenWhiteList", key = "#userId")
+    public void deleteRefreshToken(String userId) {
         // 삭제된 후 특별히 처리할 내용이 없으므로 빈 메서드로 구현
     }
 }

--- a/com.flash.auth/src/main/java/com/flash/auth/domain/exception/AuthErrorCode.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/domain/exception/AuthErrorCode.java
@@ -11,7 +11,8 @@ public enum AuthErrorCode implements ErrorCode {
     ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Access Token이 존재하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "Refresh Token이 존재하지 않습니다."),
     FAILED_REFRESH_ENCODING(HttpStatus.UNAUTHORIZED, "Refresh 토큰 인코딩 실패"),
-    UNAUTHORIZED_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    UNAUTHORIZED_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    ALREADY_SIGNED_IN_USER(HttpStatus.CONFLICT, "이미 로그인된 사용자입니다. 중복 로그인 불가");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/com.flash.auth/src/main/java/com/flash/auth/presentation/controller/AuthController.java
+++ b/com.flash.auth/src/main/java/com/flash/auth/presentation/controller/AuthController.java
@@ -33,11 +33,9 @@ public class AuthController {
         return ResponseEntity.ok(authService.join(joinRequestDto));
     }
 
-    // TODO: 로그인 요청을 계속 보내지 못하도록 막는 방법은?
     // @PreAuthorize("isAnonymous()")
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody @Valid LoginRequestDto loginRequestDto, HttpServletResponse response) {
-        // TODO: refresh token을 redis에 저장할 예정인데, 그게 있으면 return ?
         LoginResponseDto loginResponseDto = authService.attemptAuthentication(loginRequestDto);
         response.addHeader(AUTHORIZATION_HEADER, loginResponseDto.accessToken());
         response.addCookie(cookieUtil.createCookieWithRefreshToken(loginResponseDto.refreshToken()));

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 플래시 세일 이커머스 프로젝트는 짧은 시간 동안 한정된 수량의 상품을 할인된 가격에 판매하는 이벤트를 제공하는 서비스입니다.
 
-<img src="">
+<img src="https://github.com/FlashSaleF/backend/blob/dev/docs/images/flash%20sale.png?raw=true">
 
 ---
 
@@ -83,24 +83,24 @@
 
 ### 서비스 아키텍처
 
-![service_architecture](https://prod-files-secure.s3.us-west-2.amazonaws.com/83c75a39-3aba-4ba4-a792-7aefe4b07895/ab44fa60-b79d-4901-971a-a749b4b77988/%E1%84%82%E1%85%A2%E1%84%87%E1%85%AE.jpg)
+<img src="https://github.com/FlashSaleF/backend/blob/dev/docs/images/service%20architecture.jpg?raw=true">
 
----
+
 
 ### 인프라 설계도
 
-![infrastructure](https://prod-files-secure.s3.us-west-2.amazonaws.com/83c75a39-3aba-4ba4-a792-7aefe4b07895/48702e44-d7e6-4372-b2e3-06ba764df670/%E1%84%8B%E1%85%AC%E1%84%87%E1%85%AE.jpg)
+<img src="https://github.com/FlashSaleF/backend/blob/dev/docs/images/infrastructure.jpg?raw=true">
 
 ---
 
 ## 🚗 주요 기능
 
-- [⭐ 비동기 처리와 이벤트 기반 대용량 주문 처리](https://www.notion.so/1264f92830ab80f7b6bed71f7b2144d5?pvs=21)
-- [⭐ Redis 분산락을 통한 동시성 재고 관리](https://www.notion.so/Redis-8a938314f83e415283de28212e3398bd?pvs=21)
-- [플래시 세일 알림 메일 발송](https://www.notion.so/21a77b1dc9204887aa5f56c16ddf74e1?pvs=21)
-- [모니터링](https://www.notion.so/9f18c0e8d7da4ab8bb15ee425fc9c38d?pvs=21)
-- [Redis 캐싱](https://www.notion.so/Redis-35aa6aa6892749edb8636446bfa5930a?pvs=21)
-- [플래시 세일 관리](https://www.notion.so/8f25b1a96bf0411c9ba05aeea75f899d?pvs=21)
+- [⭐ 비동기 처리와 이벤트 기반 대용량 주문 처리](https://spot-decade-fee.notion.site/1264f92830ab80f7b6bed71f7b2144d5)
+- [⭐ Redis 분산락을 통한 동시성 재고 관리](https://creative-crane-389.notion.site/Redis-128707d279cc8132ad26e1bfd9c78140)
+- [플래시 세일 알림 메일 발송](https://creative-crane-389.notion.site/128707d279cc810184b5d013b5ded7c4)
+- [모니터링](https://creative-crane-389.notion.site/128707d279cc81e4bfa4c1590e86e710)
+- [Redis 캐싱](https://creative-crane-389.notion.site/Redis-128707d279cc8185b2f4d97b71e86a9c)
+- [플래시 세일 관리](https://creative-crane-389.notion.site/128707d279cc81b4aeddd30fd4bb1ebc)
 
 ---
 
@@ -123,23 +123,23 @@
 
 ## 🤔 기술적 의사결정
 
-- [Gateway에서 캐싱된 Access토큰 블랙리스트 및 화이트리스트 조회](https://www.notion.so/Gateway-Access-16e25f2be00e401e9546664b6e41c7b0?pvs=21)
-- [대규모 트래픽에서 효율적인 락 관리](https://www.notion.so/8f3f4eb0255b4b1e847a4fa118ddf6d5?pvs=21)
-- [메일 발송을 위한 동적 스케줄러 구성](https://www.notion.so/906414559da34ec7b72749149da1e7d8?pvs=21)
-- [아키텍처](https://www.notion.so/d657fe3cb7af4c45ae4ade949988f321?pvs=21)
-- [Kafka를 이용한 주문 생성](https://www.notion.so/Kafka-416f0507141b41518a43e783dfb4c0df?pvs=21)
+- [Gateway에서 캐싱된 Access토큰 블랙리스트 및 화이트리스트 조회](https://creative-crane-389.notion.site/Gateway-Access-128707d279cc8197a074f9c1ad0f28c2)
+- [대규모 트래픽에서 효율적인 락 관리](https://creative-crane-389.notion.site/128707d279cc818983eec6578e3d7a6d)
+- [메일 발송을 위한 동적 스케줄러 구성](https://creative-crane-389.notion.site/128707d279cc81c5b17cf46059782498)
+- [아키텍처](https://creative-crane-389.notion.site/128707d279cc81a8a5b6cac32605c527)
+- [Kafka를 이용한 주문 생성](https://creative-crane-389.notion.site/Kafka-128707d279cc8141a020ca70790739a2)
 
 ---
 
 ## ⚽ 트러블슈팅
 
-[Jmeter 부하테스트 ](https://www.notion.so/Jmeter-1264f92830ab809dafadf52b1b7885d2?pvs=21)
+[Jmeter 부하테스트 ](https://spot-decade-fee.notion.site/Jmeter-1264f92830ab809dafadf52b1b7885d2)
 
-[UUID 검증](https://www.notion.so/UUID-542467318a1f425cbd33231282ce36d7?pvs=21)
+[UUID 검증](https://creative-crane-389.notion.site/UUID-128707d279cc81fc8d4cc8968d7c8096)
 
-[Feignclient 에러 핸들링](https://www.notion.so/Feignclient-087cea3b28c34340b5bb4e583e1286b7?pvs=21)
+[Feignclient 에러 핸들링](https://creative-crane-389.notion.site/Feignclient-128707d279cc814cb275dd112d4b2404)
 
-[재고에 대한 분산 락 처리의 변경](https://www.notion.so/114cc2a791d948a1b845d887db2851c5?pvs=21)
+[재고에 대한 분산 락 처리의 변경](https://creative-crane-389.notion.site/128707d279cc819bb343d4fdaf545e63)
 
 ---
 


### PR DESCRIPTION
로그아웃 시 Refresh토큰의 화이트리스트를 제거할 때, userId를 파라미터로 받고 있습니다.
근데 userId가 아닌 refresh토큰 자체를 넘겨주어 제대로 작동하지 않았던 부분 fix했습니다.

또한, api 테스트 시, 다른 권한을 가진 id로 변경하며 진행하는 상황에서 혹시모를 실수를 최대한 줄이고자
이미 로그인한 id에 대해 재로그인을 시도하는 경우 예외가 발생하도록 설정하였습니다.

**api테스트 시 id를 변경하는 상황이면, 이전 id를 꼭 로그아웃 해주세요!**

추가로 README.md 최신화하였습니다.

